### PR TITLE
fix: slow server startup due to eager org enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.3] - 2026-02-19
+
+### Fixed
+
+- **Server Startup Performance**: Removed eager org enumeration from resource template list callbacks that were blocking the MCP connection during handshake. Resource templates still work on-demand via `{alias}` URI parameter and autocomplete provides discoverability without the performance penalty
+
+### Changed
+
+- **README Badges**: Added NPM downloads and GitHub downloads badges to improve visibility of project metrics
+
 ## [1.6.2] - 2026-02-16
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.3",
     "name": "salesforce-mcp-server",
     "display_name": "Salesforce MCP Server",
-    "version": "1.6.2",
+    "version": "1.6.3",
     "description": "Salesforce MCP Server - Interact with Salesforce orgs through AI assistants",
     "icon": "icon.png",
     "long_description": "Enables AI assistants to execute Apex code, query Salesforce data, and manage org metadata using your existing Salesforce CLI authentication. Perfect for developers and administrators who want to automate Salesforce tasks through natural language interactions.\n\nSupports environment variables:\n- READ_ONLY=true - Prevents Apex code execution\n- ALLOWED_ORGS=ALL or comma-separated org list - Restricts access to specific orgs (default: ALL)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@advanced-communities/salesforce-mcp-server",
-    "version": "1.6.2",
+    "version": "1.6.3",
     "description": "MCP server enabling AI assistants to interact with Salesforce orgs through the Salesforce CLI",
     "main": "./src/index.ts",
     "scripts": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
     "name": "io.github.advancedcommunities/salesforce-mcp-server",
     "title": "Salesforce MCP Server",
     "description": "MCP server enabling AI assistants to interact with Salesforce orgs through the Salesforce CLI",
-    "version": "1.6.2",
+    "version": "1.6.3",
     "websiteUrl": "https://github.com/advancedcommunities/salesforce-mcp-server/blob/main/README.MD",
     "repository": {
         "url": "https://github.com/advancedcommunities/salesforce-mcp-server",
@@ -14,7 +14,7 @@
             "registryType": "npm",
             "registryBaseUrl": "https://registry.npmjs.org",
             "identifier": "@advanced-communities/salesforce-mcp-server",
-            "version": "1.6.2",
+            "version": "1.6.3",
             "transport": {
                 "type": "stdio"
             },

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ function buildServerDescription(): string {
     const allowedOrgs = permissions.getAllowedOrgs();
     const permissionInfo = [];
 
-    let description = `Salesforce MCP Server v1.6.2 - AI-powered Salesforce automation via CLI integration\n`;
+    let description = `Salesforce MCP Server v1.6.3 - AI-powered Salesforce automation via CLI integration\n`;
     description += `Capabilities: Apex execution, SOQL queries, org management, code testing & coverage\n`;
 
     if (readOnlyMode) {
@@ -71,7 +71,7 @@ const server = new McpServer(
     {
         name: "salesforce-mcp-server",
         title: "Salesforce MCP Server",
-        version: "1.6.2",
+        version: "1.6.3",
         description: buildServerDescription(),
         ...(iconSrc && {
             icons: [
@@ -108,7 +108,7 @@ registerPrompts(server);
 async function main() {
     const transport = new StdioServerTransport();
     await server.connect(transport);
-    logger.info("salesforce", "Salesforce MCP Server v1.6.2 started");
+    logger.info("salesforce", "Salesforce MCP Server v1.6.3 started");
     console.error("Salesforce MCP Server running on stdio");
 }
 

--- a/src/resources/resources.ts
+++ b/src/resources/resources.ts
@@ -30,43 +30,14 @@ export async function getAccessibleOrgs() {
 }
 
 /**
- * Return the first alias (preferred) or username for an org.
- */
-function getOrgIdentifier(org: {
-    username: string;
-    aliases?: string[] | null;
-}): string {
-    return org.aliases?.[0] ?? org.username;
-}
-
-/**
  * Autocomplete helper for the {alias} URI variable.
  */
 export async function completeAlias(value: string): Promise<string[]> {
     const orgs = await getAccessibleOrgs();
-    const identifiers = orgs.map(getOrgIdentifier);
+    const identifiers = orgs.map((org) => org.aliases?.[0] ?? org.username);
     return identifiers.filter((id) =>
         id.toLowerCase().startsWith(value.toLowerCase()),
     );
-}
-
-/**
- * Factory that creates a `list` callback enumerating one resource per connected org.
- */
-function makeOrgResourceList(pathSuffix: string, labelSuffix: string) {
-    return async () => {
-        const orgs = await getAccessibleOrgs();
-        return {
-            resources: orgs.map((org) => {
-                const id = getOrgIdentifier(org);
-                return {
-                    uri: `salesforce://org/${id}${pathSuffix}`,
-                    name: `${id} ${labelSuffix}`,
-                    mimeType: "application/json" as const,
-                };
-            }),
-        };
-    };
 }
 
 /**
@@ -114,7 +85,7 @@ export function registerResources(server: McpServer) {
     server.registerResource(
         "org_metadata",
         new ResourceTemplate("salesforce://org/{alias}/metadata", {
-            list: makeOrgResourceList("/metadata", "metadata"),
+            list: undefined,
             complete: {
                 alias: completeAlias,
             },
@@ -174,7 +145,7 @@ export function registerResources(server: McpServer) {
     server.registerResource(
         "org_objects",
         new ResourceTemplate("salesforce://org/{alias}/objects", {
-            list: makeOrgResourceList("/objects", "objects"),
+            list: undefined,
             complete: {
                 alias: completeAlias,
             },
@@ -320,7 +291,7 @@ export function registerResources(server: McpServer) {
     server.registerResource(
         "org_limits",
         new ResourceTemplate("salesforce://org/{alias}/limits", {
-            list: makeOrgResourceList("/limits", "limits"),
+            list: undefined,
             complete: {
                 alias: completeAlias,
             },


### PR DESCRIPTION
## Summary
- Removed eager `list` callbacks from resource templates (`org_metadata`, `org_objects`, `org_limits`) that called `listAllOrgs()` during MCP handshake
- This was creating full Salesforce connections to every authenticated org at connect time, blocking the server startup for seconds
- Resources still work on-demand via `{alias}` parameter and autocomplete still works for discoverability
- Bumped version to 1.6.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)