### PR TITLE
feat: add generate_frontdoor_url tool (AIA-123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.5] - 2026-04-16
+
+### Added
+
+- **Frontdoor URL Generation**: New `generate_frontdoor_url` tool for authenticated browser access
+  - Generates a Salesforce frontdoor URL (`{instanceUrl}/secur/frontdoor.jsp?sid={accessToken}&retURL={retURL}`) using credentials from the Salesforce CLI
+  - Supports optional `targetOrg` (defaults to current default org) and `retURL` (defaults to `/`) parameters
+  - Designed for use with browser automation tools such as the Playwright MCP and Chrome DevTools MCP
+  - Respects `ALLOWED_ORGS` permission settings
+
 ## [1.6.4] - 2026-02-19
 
 ### Added

--- a/README.MD
+++ b/README.MD
@@ -735,7 +735,17 @@ Clear the default target org from the Salesforce CLI configuration. After cleari
 - "Remove the default target org setting"
 - "Unset my default org"
 
-#### 40. Install Skill
+#### 40. Generate Frontdoor URL
+
+Generate an authenticated Salesforce frontdoor URL that allows seamless browser login without re-entering credentials. Useful for browser automation tools (e.g. Playwright) that need to open an authenticated Salesforce session programmatically.
+
+**Example prompts:**
+
+- "Generate a frontdoor URL for my dev org"
+- "Get a frontdoor login URL for sandbox1 pointing to the home page"
+- "Create an authenticated URL for my org redirecting to /lightning/page/home"
+
+#### 41. Install Skill
 
 Install the Salesforce MCP Server skill for Claude Code, providing domain-specific guidance on tool usage, workflows, and best practices.
 

--- a/README.MD
+++ b/README.MD
@@ -150,7 +150,7 @@ To be able to run the MCP Server – you need a client. The client can be any AI
 
 #### Claude Code Skill
 
-The server includes an `install_skill` tool that adds a Salesforce-specific skill to Claude Code. The skill teaches Claude how to effectively use all 40 tools, 5 prompts, and 5 resources together — including tool selection guidance, workflow patterns, and common pitfalls to avoid.
+The server includes an `install_skill` tool that adds a Salesforce-specific skill to Claude Code. The skill teaches Claude how to effectively use all 41 tools, 5 prompts, and 5 resources together — including tool selection guidance, workflow patterns, and common pitfalls to avoid.
 
 **Automatic installation**: Claude can call the `install_skill` tool when working on Salesforce tasks. You can also ask Claude directly: "Install the Salesforce skill."
 
@@ -326,7 +326,7 @@ You can check the current permission settings using the `get_server_permissions`
 
 ## How to use it
 
-Once the SF MCP Server is configured in your AI client, you can interact with Salesforce using natural language. The AI assistant will have access to 40 powerful tools, 5 guided workflow prompts, 5 browsable resource types, and structured logging with progress reporting:
+Once the SF MCP Server is configured in your AI client, you can interact with Salesforce using natural language. The AI assistant will have access to 41 powerful tools, 5 guided workflow prompts, 5 browsable resource types, and structured logging with progress reporting:
 
 ### Available Tools
 

--- a/manifest.json
+++ b/manifest.json
@@ -133,6 +133,10 @@
             "description": "Open a Salesforce org in a browser"
         },
         {
+            "name": "generate_frontdoor_url",
+            "description": "Generate an authenticated Salesforce frontdoor URL for seamless browser login without re-entering credentials"
+        },
+        {
             "name": "package_install",
             "description": "Install or upgrade a package version in a Salesforce org"
         },

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.3",
     "name": "salesforce-mcp-server",
     "display_name": "Salesforce MCP Server",
-    "version": "1.6.4",
+    "version": "1.6.5",
     "description": "Salesforce MCP Server - Interact with Salesforce orgs through AI assistants",
     "icon": "icon.png",
     "long_description": "Enables AI assistants to execute Apex code, query Salesforce data, and manage org metadata using your existing Salesforce CLI authentication. Perfect for developers and administrators who want to automate Salesforce tasks through natural language interactions.\n\nSupports environment variables:\n- READ_ONLY=true - Prevents Apex code execution\n- ALLOWED_ORGS=ALL or comma-separated org list - Restricts access to specific orgs (default: ALL)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@advanced-communities/salesforce-mcp-server",
-    "version": "1.6.4",
+    "version": "1.6.5",
     "description": "MCP server enabling AI assistants to interact with Salesforce orgs through the Salesforce CLI",
     "main": "./src/index.ts",
     "scripts": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
     "name": "io.github.advancedcommunities/salesforce-mcp-server",
     "title": "Salesforce MCP Server",
     "description": "MCP server enabling AI assistants to interact with Salesforce orgs through the Salesforce CLI",
-    "version": "1.6.4",
+    "version": "1.6.5",
     "websiteUrl": "https://github.com/advancedcommunities/salesforce-mcp-server/blob/main/README.MD",
     "repository": {
         "url": "https://github.com/advancedcommunities/salesforce-mcp-server",
@@ -14,7 +14,7 @@
             "registryType": "npm",
             "registryBaseUrl": "https://registry.npmjs.org",
             "identifier": "@advanced-communities/salesforce-mcp-server",
-            "version": "1.6.4",
+            "version": "1.6.5",
             "transport": {
                 "type": "stdio"
             },

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ function buildServerDescription(): string {
     const allowedOrgs = permissions.getAllowedOrgs();
     const permissionInfo = [];
 
-    let description = `Salesforce MCP Server v1.6.4 - AI-powered Salesforce automation via CLI integration\n`;
+    let description = `Salesforce MCP Server v1.6.5 - AI-powered Salesforce automation via CLI integration\n`;
     description += `Capabilities: Apex execution, SOQL queries, org management, code testing & coverage\n`;
 
     if (readOnlyMode) {
@@ -59,7 +59,7 @@ function buildServerDescription(): string {
         description += `Security: Full access enabled for all authenticated orgs`;
     }
 
-    description += `\nTools: 40 available (apex, query, search, sobject, org management, records, admin, code analyzer, scanner, package, schema, lightning, project deployment, skill)`;
+    description += `\nTools: 41 available (apex, query, search, sobject, org management, records, admin, code analyzer, scanner, package, schema, lightning, project deployment, skill)`;
     description += `\nResources: 5 available (permissions, org metadata, objects, object schema, limits)`;
     description += `\nPrompts: 5 available (soql_builder, apex_review, org_health_check, deploy_checklist, debug_apex)`;
 
@@ -72,7 +72,7 @@ const server = new McpServer(
     {
         name: "salesforce-mcp-server",
         title: "Salesforce MCP Server",
-        version: "1.6.4",
+        version: "1.6.5",
         description: buildServerDescription(),
         ...(iconSrc && {
             icons: [
@@ -142,7 +142,7 @@ async function main() {
         };
     }
 
-    logger.info("salesforce", "Salesforce MCP Server v1.6.4 started");
+    logger.info("salesforce", "Salesforce MCP Server v1.6.5 started");
     console.error("Salesforce MCP Server running on stdio");
 }
 

--- a/src/tools/orgs.ts
+++ b/src/tools/orgs.ts
@@ -251,6 +251,28 @@ const openOrg = async (
     }
 };
 
+const generateFrontdoorUrl = async (
+    targetOrg: string,
+    retURL: string = "/",
+) => {
+    const sfCommand = `sf org display --target-org ${targetOrg} --json`;
+    const result = await executeSfCommand(sfCommand);
+
+    const instanceUrl = result?.result?.instanceUrl;
+    const accessToken = result?.result?.accessToken;
+
+    if (!instanceUrl || !accessToken) {
+        throw new Error(
+            `Could not retrieve instanceUrl or accessToken for org '${targetOrg}'. Ensure the org is authenticated.`,
+        );
+    }
+
+    const encodedRetURL = encodeURIComponent(retURL);
+    const frontdoorUrl = `${instanceUrl}/secur/frontdoor.jsp?sid=${accessToken}&retURL=${encodedRetURL}`;
+
+    return { frontdoorUrl, instanceUrl, targetOrg };
+};
+
 export const registerOrgTools = (server: McpServer) => {
     const orgInfoSchema = z.object({
         username: z.string(),
@@ -1195,6 +1217,95 @@ export const registerOrgTools = (server: McpServer) => {
                                 message:
                                     error.message ||
                                     "Failed to set default target org",
+                            }),
+                        },
+                    ],
+                };
+            }
+        },
+    );
+
+    server.registerTool(
+        "generate_frontdoor_url",
+        {
+            description:
+                "Generate an authenticated Salesforce frontdoor URL that allows seamless browser login without re-entering credentials. The URL uses the format: {instanceUrl}/secur/frontdoor.jsp?sid={accessToken}&retURL={retURL}. This is useful for programmatic browser automation tools such as the Playwright MCP and Chrome DevTools MCP that need to open an authenticated Salesforce session.",
+            inputSchema: {
+                input: z.object({
+                    targetOrg: z
+                        .string()
+                        .optional()
+                        .describe(
+                            "Username or alias of the target org. If not provided, uses the default org from SF CLI configuration.",
+                        ),
+                    retURL: z
+                        .string()
+                        .optional()
+                        .describe(
+                            "Relative URL to redirect to after login (e.g. '/lightning/page/home'). Defaults to '/'.",
+                        ),
+                }),
+            },
+            annotations: {
+                readOnlyHint: true,
+                destructiveHint: false,
+                idempotentHint: false,
+                openWorldHint: true,
+            },
+        },
+        async ({ input }) => {
+            let targetOrg: string;
+            try {
+                targetOrg = await resolveTargetOrg(input.targetOrg);
+            } catch (error: any) {
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: JSON.stringify({
+                                success: false,
+                                message: error.message,
+                            }),
+                        },
+                    ],
+                };
+            }
+
+            if (!permissions.isOrgAllowed(targetOrg)) {
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: JSON.stringify({
+                                success: false,
+                                message: `Access to org '${targetOrg}' is not allowed`,
+                            }),
+                        },
+                    ],
+                };
+            }
+
+            try {
+                const result = await generateFrontdoorUrl(
+                    targetOrg,
+                    input.retURL,
+                );
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: JSON.stringify({ success: true, ...result }),
+                        },
+                    ],
+                };
+            } catch (error: any) {
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: JSON.stringify({
+                                success: false,
+                                message: error.message,
                             }),
                         },
                     ],


### PR DESCRIPTION
## Summary

- Adds a new `generate_frontdoor_url` MCP tool to `src/tools/orgs.ts`
- Generates an authenticated Salesforce frontdoor URL (`{instanceUrl}/secur/frontdoor.jsp?sid={accessToken}&retURL={retURL}`) by calling `sf org display --json`
- Supports optional `targetOrg` (falls back to SF CLI default) and `retURL` (defaults to `/`) parameters
- Respects `ALLOWED_ORGS` permission settings; graceful error handling for unauthenticated orgs or missing CLI

## Why

Prerequisite for the automated browser testing agent (AIA-121). Browser automation tools like the **Playwright MCP** and **Chrome DevTools MCP** need a way to open an already-authenticated Salesforce session without re-entering credentials — this URL provides that.

## Reviewer notes

- Implementation follows the existing tool pattern in `orgs.ts` — uses `resolveTargetOrg`, `permissions.isOrgAllowed`, and `executeSfCommand`
- `retURL` is URL-encoded before being appended to the frontdoor URL
- Registered in `manifest.json` and documented in `README.MD` (tool #40, Install Skill renumbered to #41)
- Version bumped `1.6.4` → `1.6.5` with CHANGELOG entry

## Test plan

- [ ] Call `generate_frontdoor_url` with no arguments — should return a valid frontdoor URL for the default org
- [ ] Call with `targetOrg` and `retURL=/lightning/page/home` — URL should include the encoded retURL
- [ ] Call with an unauthenticated org — should return `{ success: false, message: ... }`
- [ ] Call when `ALLOWED_ORGS` excludes the org — should return access denied error

🤖 Generated with [Claude Code](https://claude.com/claude-code)